### PR TITLE
use newer versions

### DIFF
--- a/puzzlib.cabal
+++ b/puzzlib.cabal
@@ -20,81 +20,81 @@ library
                      , Markov
                      , Morse
   -- other-modules:       
-  build-depends:       base ==4.6.*
+  build-depends:       base ==4.8.*
                      , bytestring ==0.10.*
                      , containers ==0.5.*
-                     , unordered-containers ==0.2.3.*
+                     , unordered-containers ==0.2.7.*
 
 executable cryptosearch
     hs-source-dirs: cryptosearch
     main-is:        Main.hs
-    build-depends:     base ==4.6.*
+    build-depends:     base ==4.8.*
                      , bytestring ==0.10.*
                      , puzzlib
 
 executable caesar
     hs-source-dirs: caesar
     main-is:        Main.hs
-    build-depends:     base ==4.6.*
+    build-depends:     base ==4.8.*
                      , puzzlib
 
 -- Tools for analyzing corpus
 executable corpuswords
     hs-source-dirs: analyze_corpus
     main-is:        GetWords.hs
-    build-depends:     base ==4.6.*
+    build-depends:     base ==4.8.*
                      , bytestring ==0.10.*
                      , containers ==0.5.*
                      , directory ==1.2.*
-                     , filepath ==1.3.*
+                     , filepath ==1.4.*
                      , puzzlib
-                     , unix ==2.6.*
+                     , unix ==2.7.*
 
 executable counts
     hs-source-dirs: analyze_corpus
     main-is:        BuildFrequencyTable.hs
-    build-depends:     base ==4.6.*
+    build-depends:     base ==4.8.*
                      , bytestring ==0.10.*
                      , containers ==0.5.*
                      , directory ==1.2.*
-                     , filepath ==1.3.*
+                     , filepath ==1.4.*
                      , puzzlib
-                     , unix ==2.6.*
+                     , unix ==2.7.*
 
 executable letterfreq
     hs-source-dirs: analyze_corpus
     main-is:        LetterFrequency.hs
-    build-depends:     base ==4.6.*
+    build-depends:     base ==4.8.*
                      , bytestring ==0.10.*
                      , containers ==0.5.*
                      , directory ==1.2.*
-                     , filepath ==1.3.*
+                     , filepath ==1.4.*
                      , puzzlib
-                     , unix ==2.6.*
+                     , unix ==2.7.*
 
 executable numeracy
     hs-source-dirs: numeracy
     main-is:        Main.hs
-    build-depends:     base ==4.6.*
+    build-depends:     base ==4.8.*
 
 executable morsify
     hs-source-dirs: morsify
     main-is:        Main.hs
-    build-depends:     base ==4.6.*
+    build-depends:     base ==4.8.*
                      , puzzlib
 
 executable unmorse
     hs-source-dirs: unmorse
     main-is:        Main.hs
-    build-depends:     base ==4.6.*
+    build-depends:     base ==4.8.*
                      , puzzlib
 
 executable wsearch
     hs-source-dirs: wsearch
     main-is:        Main.hs
-    build-depends:     base ==4.6.*
+    build-depends:     base ==4.8.*
 
 executable anagram
     hs-source-dirs: anagram
     main-is:        Main.hs
-    build-depends:     base ==4.6.*
+    build-depends:     base ==4.8.*


### PR DESCRIPTION
I wanted to use puzzlib but ran into trouble cause it was using an old version of base
